### PR TITLE
build: segregate prettier and eslint

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,8 @@
 {
   "recommendations": [
-    "rohit-gohri.format-code-action",
     "esbenp.prettier-vscode",
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "github.vscode-pull-request-github",
+    "visualstudioexptteam.vscodeintellicode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,19 @@
 {
+  "eslint.format.enable": true,
+  "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": false,
-  "editor.codeActionsOnSave": ["source.fixAll.format", "source.fixAll.eslint"],
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
   "emmet.includeLanguages": {
     "javascript": "javascriptreact"
   }


### PR DESCRIPTION
these two formatters don't work well together, but prettier can still be called manually on files in vscode using ctrl+shift+p 'format document with', which helps avoid lines going over 80-100 characters

in addition two new extensions were added as recommendations: github pull requests for better collaboration using the "TODO @username" convention and intellicode for assisted intellisense