### PR TITLE
ci: upgrade Continuous Integration workflow version, triggers, and job depedencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,11 +3,12 @@
 name: Continuous Integration
 
 on:
+  workflow_dispatch:
   pull_request:
-    branches:
-      - dev
-      - master
   push:
+    branches:
+      - main
+      - integration
 
 jobs:
   checks:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,85 +10,22 @@ on:
   push:
 
 jobs:
-  lint:
-    name: Lint
+  checks:
+    name: checks
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        command: [lint, test:unit, test:types]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 14
+          cache: npm
 
-      - name: Cache Node.js modules
-        uses: actions/cache@v1
-        with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+      - run: npm ci
 
-      - name: Install npm dependencies
-        run: npm i
-
-      - name: Run linter
-        run: npm run lint
-
-  unit-tests:
-    name: Unit Tests
-    runs-on: macos-latest
-    needs: lint
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-
-      - name: Cache Node.js modules
-        uses: actions/cache@v1
-        with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
-
-      - name: Install npm dependencies
-        run: npm i
-
-      - name: Run tests
-        run: npm run test:unit
-
-  typechecking-tests:
-    name: Typechecking Tests
-    runs-on: ubuntu-latest
-    needs: lint
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-
-      - name: Cache Node.js modules
-        uses: actions/cache@v1
-        with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
-
-      - name: Install npm dependencies
-        run: npm i
-
-      - name: Run tests
-        run: npm run test:types
+      - run: npm run ${{ matrix.command }}


### PR DESCRIPTION
### Summary of PR
Overall, makes the CI workflow faster by removing job dependencies, using a consistent environment, and upgrading to use the new `setup-node@v2` action which has in-built caching!

Changes the target branch to main as per #152.
