### PR TITLE
ci: add workflow to sync ios provisioning certificates with match

### DIFF
--- a/.github/workflows/sync-code-signing.yml
+++ b/.github/workflows/sync-code-signing.yml
@@ -1,0 +1,28 @@
+name: Sync Certificates
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 * * SUN
+
+concurrency: sync-certificates
+
+jobs:
+  sync-certificates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - run: bundle exec fastlane match
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
+          MATCH_REPOSITORY: https://${{ secrets.GH_BOT_TOKEN }}@github.com/shabados/ios-certificates.git
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          GIT_FULL_NAME: Shabad OS Bot
+          GIT_USER_EMAIL: team@shabados.com

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,3 +1,4 @@
-json_key_file("") # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
+identifier = 'com.shabados.app'
 
-package_name("com.shabados.mobile")
+app_identifier(identifier)
+package_name(identifier)

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,0 +1,8 @@
+git_full_name(ENV['GIT_FULL_NAME'])
+git_user_email(ENV['GIT_USER_EMAIL'])
+
+git_url(ENV['MATCH_REPOSITORY'])
+
+app_identifier(
+  CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
+)


### PR DESCRIPTION
### Summary of PR
Adds a workflow that runs every week to run `fastlane match`, which will synchronise iOS certificates
