### PR TITLE
fix: remove prerelease component from App Store builds

### DIFF
--- a/fastlane/utils.rb
+++ b/fastlane/utils.rb
@@ -5,7 +5,7 @@ def read_json(params)
 end
 
 def get_version
-  version = read_json(path: '../package.json')['version']
+  version, = read_json(path: '../package.json')['version'].split('-')
 
   return version
 end


### PR DESCRIPTION
### Summary of PR
As per #6, the app store does not accept prerelease components `-next.0` in the version name. Whilst the google play store does, this PR removes the prerelease component from both for now - we can improve later on if there is an issue.
