### PR TITLE
[PoC] Adjust Gurmukhi font size based on feature flag

### DIFF
--- a/src/screens/Gurbani/Line.tsx
+++ b/src/screens/Gurbani/Line.tsx
@@ -5,6 +5,7 @@ import Typography from '../../components/Typography'
 import Languages from '../../helpers/languages'
 import OS from '../../helpers/os'
 import transliterators from '../../helpers/transliterators'
+import { useFeatureStatus } from '../../services/feature'
 import Colors from '../../themes/colors'
 import Fonts from '../../themes/fonts'
 import Units from '../../themes/units'
@@ -17,9 +18,15 @@ const styles = StyleSheet.create( {
     ...( OS.android && { fontFamily: Fonts.MuktaMahee } ),
     lineHeight: Units.Base * Units.GurmukhiLineHeightMultiplier,
   },
+  largeFont: {
+    fontSize: Units.Base * Units.GurmukhiLatinRatio * 1.2,
+  },
   root: {
     ...px( 20 ),
     paddingTop: Units.Base * Units.LineHeightMultiplier,
+  },
+  smallFont: {
+    fontSize: ( Units.Base * Units.GurmukhiLatinRatio ) / 1.2,
   },
   text: {
     color: Colors.SecondaryText,
@@ -44,6 +51,13 @@ export type LineProps = {
   transliterations: ( Languages.English | Languages.Hindi | Languages.Urdu )[],
 }
 
+const getGurmukhiFontStyle = ( size: ReturnType<typeof useFeatureStatus> ) => {
+  if ( size === 'small' ) return styles.smallFont
+  if ( size === 'large' ) return styles.largeFont
+
+  return null
+}
+
 /**
  * Renders the Gurmukhi, any translations, and transliterates the Gurmukhi.
  */
@@ -51,26 +65,34 @@ const Line = ( {
   gurmukhi,
   translations,
   transliterations,
-}: LineProps ) => (
-  <View style={styles.root}>
-    <Typography style={[ styles.gurbani ]}>{toUnicode( gurmukhi )}</Typography>
+}: LineProps ) => {
+  const fontSizeStyle = getGurmukhiFontStyle( useFeatureStatus( 'gurmukhi_font_size' ) )
 
-    {transliterations.map( ( language ) => (
-      <Typography
-        key={language}
-        style={[ styles.text, styles.transliteration ]}
-      >
-        {transliterators[ language ]( toUnicode( gurmukhi ) )}
-      </Typography>
-    ) )}
+  return (
+    <View style={styles.root}>
+      <Typography style={[ styles.gurbani, fontSizeStyle ]}>{toUnicode( gurmukhi )}</Typography>
 
-    {translations
-      .filter( ( { translationSourceId } ) => translationSourceId === Languages.English )
-      .map( ( {
-        translationSourceId,
-        translation,
-      } ) => <Typography key={translationSourceId} style={styles.text}>{translation}</Typography> )}
-  </View>
-)
+      {transliterations.map( ( language ) => (
+        <Typography
+          key={language}
+          style={[ styles.text, styles.transliteration ]}
+        >
+          {transliterators[ language ]( toUnicode( gurmukhi ) )}
+        </Typography>
+      ) )}
+
+      {translations
+        .filter( ( { translationSourceId } ) => translationSourceId === Languages.English )
+        .map( ( { translationSourceId, translation } ) => (
+          <Typography
+            key={translationSourceId}
+            style={styles.text}
+          >
+            {translation}
+          </Typography>
+        ) )}
+    </View>
+  )
+}
 
 export default Line

--- a/src/services/feature/split/defaults.ts
+++ b/src/services/feature/split/defaults.ts
@@ -7,7 +7,7 @@ export const getDefaultAttributes = (): SplitAttributes => ( {
 } )
 
 const defaultStatuses: { [Key in keyof SplitFeatures]: SplitFeatures[Key] } = {
-
+  gurmukhi_font_size: 'normal',
 }
 
 export const getDefaultStatus = ( key: keyof SplitFeatures ) => defaultStatuses[ key ]

--- a/src/services/feature/split/types.ts
+++ b/src/services/feature/split/types.ts
@@ -9,5 +9,5 @@ export type SplitAttributes = {
 }
 
 export type SplitFeatures = {
-
+  gurmukhi_font_size: 'small' | 'normal' | 'large',
 }


### PR DESCRIPTION
## Summary

Related #206 
Closes #208

A feature flag to demonstrate that our service works has been setup - this adjusts the font size of Gurmukhi in the app based on the value.

There are 3 supported flag modes: `small`, `normal`, `large`. Currently, iOS users identified by Split have been set to large, and android to small. If the app has not had a chance to download the latest Split feature flags and cache them, it'll fallback to a value of `normal`.

Largely, this PR demonstrates the simplicity of adding feature flags and is a reference for how to do it in the future.

## Screenshot

Android & iOS:
![image](https://user-images.githubusercontent.com/1184274/149628703-2abf40f9-05aa-4ee4-8944-9cda6b312e2a.png)

Split feature flag:
![image](https://user-images.githubusercontent.com/1184274/149628733-bf2f6d2d-506b-4d97-b22c-c8fae36d0e94.png)
