### PR TITLE
build: update eslint-plugin-react-native to ^4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-react": "^7.27.1",
         "eslint-plugin-react-hooks": "^4.3.0",
-        "eslint-plugin-react-native": "^3.11.0",
+        "eslint-plugin-react-native": "^4.0.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "faker": "^5.5.3",
         "fishery": "^2.1.0",
@@ -7667,13 +7667,17 @@
       }
     },
     "node_modules/eslint-plugin-react-native": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-native/-/eslint-plugin-react-native-3.11.0.tgz",
-      "integrity": "sha512-7F3OTwrtQPfPFd+VygqKA2VZ0f2fz0M4gJmry/TRE18JBb94/OtMxwbL7Oqwu7FGyrdeIOWnXQbBAveMcSTZIA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-native/-/eslint-plugin-react-native-4.0.0.tgz",
+      "integrity": "sha512-kMmdxrSY7A1WgdqaGC+rY/28rh7kBGNBRsk48ovqkQmdg5j4K+DaFmegENDzMrdLkoufKGRNkKX6bgSwQTCAxQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.7.4",
         "eslint-plugin-react-native-globals": "^0.1.1"
+      },
+      "peerDependencies": {
+        "eslint": "^3.17.0 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-react-native-globals": {
@@ -23397,9 +23401,9 @@
       "dev": true
     },
     "eslint-plugin-react-native": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-native/-/eslint-plugin-react-native-3.11.0.tgz",
-      "integrity": "sha512-7F3OTwrtQPfPFd+VygqKA2VZ0f2fz0M4gJmry/TRE18JBb94/OtMxwbL7Oqwu7FGyrdeIOWnXQbBAveMcSTZIA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-native/-/eslint-plugin-react-native-4.0.0.tgz",
+      "integrity": "sha512-kMmdxrSY7A1WgdqaGC+rY/28rh7kBGNBRsk48ovqkQmdg5j4K+DaFmegENDzMrdLkoufKGRNkKX6bgSwQTCAxQ==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.7.4",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-react-hooks": "^4.3.0",
-    "eslint-plugin-react-native": "^3.11.0",
+    "eslint-plugin-react-native": "^4.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "faker": "^5.5.3",
     "fishery": "^2.1.0",


### PR DESCRIPTION
## Summary

If React Native styles were incorrectly ordered, ESLint would break as the `eslint-plugin`react-native` package is out of date. This PR fixes this.