### PR TITLE
Add Jest mocks for SDKs and native libraries + rework Split logic

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        command: ['lint', 'test:unit', 'test:types']
+        command: ['lint', 'test:unit -- --ci --forceExit', 'test:types']
     steps:
       - uses: actions/checkout@v2
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -11,8 +11,5 @@ module.exports = {
     production: {
       plugins: [ 'transform-remove-console' ],
     },
-    test: {
-      plugins: [ 'react-native-config-node/transform', 'transform-remove-console' ],
-    },
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@typescript-eslint/parser": "^5.4.0",
         "babel-jest": "^27.4.2",
         "babel-plugin-transform-remove-console": "^6.9.4",
+        "dotenv": "^12.0.3",
         "eslint": "^8.3.0",
         "eslint-config-airbnb": "^19.0.1",
         "eslint-config-airbnb-typescript": "^16.0.0",
@@ -69,7 +70,6 @@
         "npm-run-all": "^4.1.5",
         "pod-install": "^0.1.29",
         "prettier": "2.5.0",
-        "react-native-config-node": "^0.0.3",
         "react-test-renderer": "^17.0.2",
         "typescript": "^4.5.2"
       },
@@ -6867,12 +6867,12 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-12.0.3.tgz",
+      "integrity": "sha512-RlOysyzyGiABgDFgITo5fRnMV1QStdoVvkXhnxQc5Or/CiQo52s2Bh6DVMvzZsmFQ9IrNxYHOC/gdpNwHsitnQ==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/ee-first": {
@@ -14911,15 +14911,6 @@
         }
       }
     },
-    "node_modules/react-native-config-node": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/react-native-config-node/-/react-native-config-node-0.0.3.tgz",
-      "integrity": "sha512-AZgVrUxJtEvQqSN2W5zlVdZDbxTn9YNohUfQ51SCPASlYSU0Nx3G8m8+9XSWUv0iN66rwPNoywPrhxwr/V9OVg==",
-      "dev": true,
-      "dependencies": {
-        "dotenv": "^8.2.0"
-      }
-    },
     "node_modules/react-native-device-info": {
       "version": "8.4.8",
       "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-8.4.8.tgz",
@@ -22573,9 +22564,9 @@
       }
     },
     "dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-12.0.3.tgz",
+      "integrity": "sha512-RlOysyzyGiABgDFgITo5fRnMV1QStdoVvkXhnxQc5Or/CiQo52s2Bh6DVMvzZsmFQ9IrNxYHOC/gdpNwHsitnQ==",
       "dev": true
     },
     "ee-first": {
@@ -28852,15 +28843,6 @@
       "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.4.5.tgz",
       "integrity": "sha512-5oiAsoW88SOYDg/0cleJ2vJDqv98FJUbFQYEnH4sdMtEn3AAT3lb7BkTGW8HO/t3Vk9VOruwxUUnO4tzuxzCsw==",
       "requires": {}
-    },
-    "react-native-config-node": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/react-native-config-node/-/react-native-config-node-0.0.3.tgz",
-      "integrity": "sha512-AZgVrUxJtEvQqSN2W5zlVdZDbxTn9YNohUfQ51SCPASlYSU0Nx3G8m8+9XSWUv0iN66rwPNoywPrhxwr/V9OVg==",
-      "dev": true,
-      "requires": {
-        "dotenv": "^8.2.0"
-      }
     },
     "react-native-device-info": {
       "version": "8.4.8",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@typescript-eslint/parser": "^5.4.0",
     "babel-jest": "^27.4.2",
     "babel-plugin-transform-remove-console": "^6.9.4",
+    "dotenv": "^12.0.3",
     "eslint": "^8.3.0",
     "eslint-config-airbnb": "^19.0.1",
     "eslint-config-airbnb-typescript": "^16.0.0",
@@ -87,7 +88,6 @@
     "npm-run-all": "^4.1.5",
     "pod-install": "^0.1.29",
     "prettier": "2.5.0",
-    "react-native-config-node": "^0.0.3",
     "react-test-renderer": "^17.0.2",
     "typescript": "^4.5.2"
   }

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -5,9 +5,7 @@ import App from './App'
 describe( 'App', () => {
   describe( 'Initial load', () => {
     it( 'Renders without crashing', async () => {
-      const { unmount } = render( <App /> )
-
-      unmount()
+      render( <App /> )
     } )
   } )
 } )

--- a/src/__mocks__/react-native-config/index.ts
+++ b/src/__mocks__/react-native-config/index.ts
@@ -1,0 +1,12 @@
+import dotenv from 'dotenv'
+import { readFileSync } from 'fs'
+
+const main = () => {
+  const { ENVFILE } = process.env
+
+  const envFile = readFileSync( ENVFILE! )
+
+  return dotenv.parse( envFile )
+}
+
+export default main()

--- a/src/services/feature/hooks.spec.tsx
+++ b/src/services/feature/hooks.spec.tsx
@@ -36,19 +36,6 @@ const setup = ( { client, ...props }: SetupParams ) => {
 }
 
 describe( 'useFeatureEnabled', () => {
-  describe( 'given the feature service client is not ready', () => {
-    it( 'should return a non-truthy value', () => {
-      const client: Partial<DefaultClient> = {
-        isReady: () => false,
-        isEnabled: () => false,
-      }
-
-      const { queryByText } = setup( { client } )
-
-      expect( queryByText( /test_feature/ ) ).toBeFalsy()
-    } )
-  } )
-
   describe( 'given the feature service client is ready', () => {
     it( 'should update the value from the feature service when ready', async () => {
       let isEnabled = false
@@ -85,15 +72,13 @@ describe( 'useFeatureEnabled', () => {
 } )
 
 describe( 'useFeatureStatus', () => {
-  describe( 'given the feature service client is ready', () => {
-    it( 'should return the status of a flag', () => {
-      const client: Partial<DefaultClient> = {
-        getStatus: () => 'red_stars',
-      }
+  it( 'should return the status of a flag', () => {
+    const client: Partial<DefaultClient> = {
+      getStatus: () => 'red_stars',
+    }
 
-      const { queryByText } = setup( { client } )
+    const { queryByText } = setup( { client } )
 
-      expect( queryByText( /red_stars/ ) ).toBeTruthy()
-    } )
+    expect( queryByText( /red_stars/ ) ).toBeTruthy()
   } )
 } )

--- a/src/services/feature/split/__mocks__/adapter.ts
+++ b/src/services/feature/split/__mocks__/adapter.ts
@@ -1,0 +1,26 @@
+import { FeatureFlagClient } from '../../types'
+import { getDefaultStatus } from '../defaults'
+import { OffTreatment, SplitAttributes, SplitFeatures } from '../types'
+
+// Returns default feature value
+const mockAdapterFactory = (): FeatureFlagClient<SplitFeatures, SplitAttributes> => {
+  const getStatus = <Key extends keyof SplitFeatures>(
+    key: Key,
+    _attributes?: SplitAttributes,
+  ) => getDefaultStatus( key )
+
+  const isEnabled = (
+    key: keyof SplitFeatures,
+    attributes?: SplitAttributes,
+  ) => getStatus( key, attributes ) as OffTreatment !== 'off'
+
+  return {
+    getStatus,
+    isEnabled,
+    onUpdate: () => {},
+    onReady: () => {},
+    isReady: () => true,
+  }
+}
+
+export default mockAdapterFactory

--- a/src/services/feature/split/adapter.spec.tsx
+++ b/src/services/feature/split/adapter.spec.tsx
@@ -1,0 +1,128 @@
+import Split from '@splitsoftware/splitio-react-native'
+
+import nextTick from '../../../../test/utils/next-tick'
+import adapterFactory from './adapter'
+import * as defaults from './defaults'
+
+const featureStatuses = {
+  test_key: 'real_value',
+  another_key: 'another_real_value',
+  some_key: 'on',
+  off_feature: 'off',
+}
+
+const featureDefaults = {
+  test_key: 'default_value',
+  another_key: 'some default',
+  some_key: 'off',
+  off_feature: 'on',
+}
+
+const setDefaults = ( overrides: { [key in string]: string } ) => jest
+  .spyOn( defaults, 'getDefaultStatus' )
+  .mockImplementation( ( key: string ) => overrides[ key ] )
+
+jest.unmock( './adapter' )
+jest.mock( '@splitsoftware/splitio-react-native', () => {
+  const splitActual: typeof Split = jest.requireActual( '@splitsoftware/splitio-react-native' )
+
+  return {
+    ...splitActual,
+    SplitFactory: () => splitActual.SplitFactory( {
+      core: { authorizationKey: 'localhost', key: 'some_key' },
+      sync: { localhostMode: splitActual.LocalhostFromObject() },
+      // Mock splits and treatments "online" values
+      features: featureStatuses,
+    } ),
+  }
+} )
+
+type RelaxedGetter = ( key: keyof typeof featureStatuses ) => string
+
+const setup = () => {
+  setDefaults( featureDefaults )
+
+  const adapter = adapterFactory()
+
+  return {
+    ...adapter,
+    getStatus: adapter.getStatus as RelaxedGetter,
+    isEnabled: adapter.isEnabled as unknown as RelaxedGetter,
+  }
+}
+
+describe( 'Feature service split adapter', () => {
+  describe( 'when the SDK is not ready', () => {
+    describe( 'getStatus', () => {
+      it( 'should return the default value for a feature key', () => {
+        const adapter = setup()
+
+        const status = adapter.getStatus( 'test_key' )
+
+        expect( status ).toEqual( featureDefaults.test_key )
+      } )
+    } )
+
+    describe( 'isEnabled(key)', () => {
+      it( 'should return true for any default status that is not off', () => {
+        const adapter = setup()
+
+        const isEnabled = adapter.isEnabled( 'test_key' )
+
+        expect( isEnabled ).toBeTruthy()
+      } )
+
+      it( 'should return false for any default status that is off', () => {
+        const adapter = setup()
+
+        const isEnabled = adapter.isEnabled( 'some_key' )
+
+        expect( isEnabled ).toBeFalsy()
+      } )
+    } )
+  } )
+
+  describe( 'when the SDK is ready', () => {
+    it( 'should fire onReady()', async () => {
+      const onReady = jest.fn()
+      const adapter = setup()
+
+      adapter.onReady( onReady )
+      await nextTick()
+
+      expect( onReady ).toHaveBeenCalledTimes( 1 )
+      expect( adapter.isReady() ).toBeTruthy()
+    } )
+
+    describe( 'getStatus(key)', () => {
+      it( 'should return the true value for a feature key', async () => {
+        const adapter = setup()
+        await nextTick()
+
+        const status = adapter.getStatus( 'test_key' )
+
+        expect( status ).toEqual( featureStatuses.test_key )
+      } )
+    } )
+
+    describe( 'isEnabled(key)', () => {
+      it( 'should return true for any status that is not off', async () => {
+        const adapter = setup()
+        await nextTick()
+
+        const isEnabled = adapter.isEnabled( 'test_key' )
+
+        expect( isEnabled ).toBeTruthy()
+      } )
+
+      it( 'should return false for any status that is off', async () => {
+        const adapter = setup()
+        await nextTick()
+
+        const isEnabled = adapter.isEnabled( 'off_feature' )
+
+        expect( isEnabled ).toBeFalsy()
+      } )
+    } )
+  } )
+} )

--- a/src/services/feature/split/adapter.ts
+++ b/src/services/feature/split/adapter.ts
@@ -17,12 +17,10 @@ const splitAdapterFactory = (): FeatureFlagClient<SplitFeatures, SplitAttributes
   } ).client()
 
   const { get: isReady, set: setReady } = mutableValue( false )
+  client.once( client.Event.SDK_READY, () => setReady( true ) )
 
   const onUpdate = ( callback: () => void ) => client.on( client.Event.SDK_UPDATE, callback )
-  const onReady = ( callback: () => void ) => client.once( client.Event.SDK_READY, () => {
-    setReady( true )
-    callback()
-  } )
+  const onReady = ( callback: () => void ) => client.once( client.Event.SDK_READY, callback )
 
   const getStatus = <Key extends keyof SplitFeatures>( key: Key, attributes?: Attributes ) => {
     const status = client.getTreatment(

--- a/src/services/feature/split/adapter.ts
+++ b/src/services/feature/split/adapter.ts
@@ -24,18 +24,21 @@ const splitAdapterFactory = (): FeatureFlagClient<SplitFeatures, SplitAttributes
     callback()
   } )
 
-  const getStatus = <Key extends keyof SplitFeatures>( key: Key, attributes?: Attributes ) => client
-    .getTreatment( key, { ...getDefaultAttributes(), ...attributes } ) as SplitFeatures[Key]
+  const getStatus = <Key extends keyof SplitFeatures>( key: Key, attributes?: Attributes ) => {
+    const status = client.getTreatment(
+      key,
+      { ...getDefaultAttributes(), ...attributes },
+    ) as SplitFeatures[Key] | ControlTreatment
 
-  const isEnabled = ( key: keyof SplitFeatures, attributes?: Attributes ) => {
-    const status = getStatus( key, attributes ) as ControlTreatment | OffTreatment
-
-    const statusWithFallback = status === 'control'
+    return status === 'control'
       ? getDefaultStatus( key )
       : status
-
-    return statusWithFallback !== 'off'
   }
+
+  const isEnabled = (
+    key: keyof SplitFeatures,
+    attributes?: Attributes,
+  ) => getStatus( key, attributes ) as OffTreatment !== 'off'
 
   return {
     getStatus,

--- a/test/setup-jest.js
+++ b/test/setup-jest.js
@@ -1,6 +1,8 @@
 // Mock out native animations
 import 'react-native-gesture-handler/jestSetup'
 
+import mockRNDeviceInfo from 'react-native-device-info/jest/react-native-device-info-mock'
+
 jest.mock( 'react-native-reanimated', () => {
   const Reanimated = require( 'react-native-reanimated/mock' )
 
@@ -13,3 +15,7 @@ jest.mock( 'react-native-reanimated', () => {
 // Silence the warning:
 // Animated: `useNativeDriver` is not supported because the native animated module is missing
 jest.mock( 'react-native/Libraries/Animated/NativeAnimatedHelper' )
+
+jest.mock( 'react-native/Libraries/EventEmitter/NativeEventEmitter' )
+
+jest.mock( 'react-native-device-info', () => mockRNDeviceInfo )

--- a/test/setup-jest.js
+++ b/test/setup-jest.js
@@ -19,3 +19,5 @@ jest.mock( 'react-native/Libraries/Animated/NativeAnimatedHelper' )
 jest.mock( 'react-native/Libraries/EventEmitter/NativeEventEmitter' )
 
 jest.mock( 'react-native-device-info', () => mockRNDeviceInfo )
+
+jest.mock( '../src/services/feature/split/adapter' )

--- a/test/utils/next-tick.ts
+++ b/test/utils/next-tick.ts
@@ -1,0 +1,5 @@
+// Waits for next process tick to happen
+// Allows callbacks etc to fire
+const nextTick = () => new Promise( ( resolve ) => { process.nextTick( resolve ) } )
+
+export default nextTick


### PR DESCRIPTION
## Summary

This PR largely adds better OOTB support for tests written in Jests given the introduction of an externally facing SDK on the codepath and the usage of native modules. Namely:
- Add a mock adapter for split
- Mock out React Native Device Info native module
 
Additionally, this PR amends where the logic for fallback is by moving it to `getStatus`, earlier in the chain.