### PR TITLE
fix: use react-query primitive for retaining previous data

### DIFF
--- a/src/screens/Search/index.tsx
+++ b/src/screens/Search/index.tsx
@@ -1,10 +1,10 @@
 import { StackScreenProps } from '@react-navigation/stack'
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useLayoutEffect, useState } from 'react'
 import { useQuery } from 'react-query'
 
 import Container from '../../components/Container'
 import { search } from '../../services/data/search'
-import { ContentType, SearchData } from '../../types/data'
+import { ContentType } from '../../types/data'
 import Screens, { AppStackParams } from '../screens'
 import Navbar from './Navbar'
 import Results, { ResultsProps } from './Results'
@@ -18,10 +18,8 @@ const SearchScreen = ( { navigation }: SearchScreenProps ) => {
   const [ searchValue, setSearch ] = useState( '' )
   console.log( `Searching: ${searchValue}` )
 
-  const previousData = useRef<SearchData[]>()
-  const { data } = useQuery( searchValue, searchQuery, { placeholderData: previousData.current } )
+  const { data } = useQuery( searchValue, searchQuery, { keepPreviousData: true } )
   console.log( `Search Result: ${JSON.stringify( data )}` )
-  useEffect( () => { previousData.current = data }, [ data ] )
 
   const handleTextChange = ( text: string ) => setSearch( text )
 
@@ -36,7 +34,7 @@ const SearchScreen = ( { navigation }: SearchScreenProps ) => {
 
   return (
     <Container>
-      {data && ( <Results results={data} onPress={openShabad} /> )}
+      {!!data && <Results results={data} onPress={openShabad} />}
     </Container>
   )
 }


### PR DESCRIPTION
## Summary

This PR removes the excess logic around trying to manage keeping the previous data loaded until the new results have returned - there is simply a flag that does this already in `react-query`. This eliminates any bugs from the homegrown implementation of this.

The remaining errors have been observed to be 502 service failures, to do with the GN service itself.