### PR TITLE
feat: use colors from OS where possible

### DIFF
--- a/src/components/DefaultFallback.tsx
+++ b/src/components/DefaultFallback.tsx
@@ -14,7 +14,7 @@ const styles = StyleSheet.create( {
 
 const DefaultFallback = () => (
   <Container style={styles.root}>
-    <Pulse color={Colors.PrimaryText} />
+    <Pulse color={Colors.PrimaryText as string} />
   </Container>
 )
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
-import { OpaqueColorValue, StatusBar, StyleSheet, View } from 'react-native'
+import { ColorValue, StatusBar, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Colors from '../themes/colors'
@@ -28,7 +28,7 @@ type NavbarProps = {
   /**
    * A valid background colour.
    */
-  backgroundColor?: OpaqueColorValue | string,
+  backgroundColor?: ColorValue,
   /**
    * The main element, centered.
    */

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -54,7 +54,7 @@ const Navbar = ( {
   right,
 }: NavbarProps ) => (
   <View style={[ { backgroundColor } ]}>
-    <StatusBar translucent barStyle="light-content" backgroundColor={backgroundColor} />
+    <StatusBar />
     <SafeAreaView edges={[ 'left', 'top', 'right' ]} />
 
     <View style={styles.header}>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
-import { StatusBar, StyleSheet, View } from 'react-native'
+import { OpaqueColorValue, StatusBar, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import Colors from '../themes/colors'
@@ -28,7 +28,7 @@ type NavbarProps = {
   /**
    * A valid background colour.
    */
-  backgroundColor?: string,
+  backgroundColor?: OpaqueColorValue | string,
   /**
    * The main element, centered.
    */

--- a/src/screens/Gurbani/BottomBar.tsx
+++ b/src/screens/Gurbani/BottomBar.tsx
@@ -52,8 +52,8 @@ const BottomBar = () => {
 
       <LinearGradient
         style={styles.background}
-        locations={gradients.TransparentToBlack.locations}
-        colors={gradients.TransparentToBlack.colors}
+        locations={gradients.TransparentToBackground.locations}
+        colors={gradients.TransparentToBackground.colors}
       />
 
       <View style={styles.container}>

--- a/src/screens/Gurbani/BottomBar.tsx
+++ b/src/screens/Gurbani/BottomBar.tsx
@@ -15,7 +15,7 @@ import Screens, { AppStackParams } from '../screens'
 const styles = StyleSheet.create( {
   background: {
     position: 'absolute',
-    top: -10,
+    top: -20,
     bottom: 0,
     left: 0,
     right: 0,
@@ -33,9 +33,6 @@ const styles = StyleSheet.create( {
     flexDirection: 'row',
     alignItems: 'center',
   },
-  root: {
-    marginTop: 'auto',
-  },
   searchBarContainer: {
     flex: 1,
   },
@@ -48,8 +45,7 @@ const BottomBar = () => {
   const onCollectionsPress = () => navigation.navigate( Screens.Collections )
 
   return (
-    <SafeAreaView style={styles.root} edges={[ 'bottom', 'left', 'right' ]}>
-
+    <SafeAreaView edges={[ 'bottom', 'left', 'right' ]}>
       <LinearGradient
         style={styles.background}
         locations={gradients.TransparentToBackground.locations}

--- a/src/screens/Gurbani/Lines.tsx
+++ b/src/screens/Gurbani/Lines.tsx
@@ -7,12 +7,14 @@ import { LineData } from '../../types/data'
 import Line from './Line'
 
 const styles = StyleSheet.create( {
+  container: {
+    overflow: 'visible',
+  },
   linesContent: {
     paddingBottom: 63 + ( Units.Base * Units.LineHeightMultiplier ) / 2,
   },
   root: {
     flex: 1,
-    marginBottom: -63,
   },
 } )
 
@@ -45,7 +47,12 @@ export type LineProps = {
  */
 const Lines = ( { lines }: LineProps ) => (
   <View style={styles.root}>
-    <FlatList contentContainerStyle={styles.linesContent} data={lines} renderItem={renderLine} />
+    <FlatList
+      style={styles.container}
+      contentContainerStyle={styles.linesContent}
+      data={lines}
+      renderItem={renderLine}
+    />
   </View>
 )
 

--- a/src/themes/colors.ts
+++ b/src/themes/colors.ts
@@ -1,4 +1,4 @@
-import { Appearance, ColorValue, Platform, PlatformColor } from 'react-native'
+import { ColorValue, Platform, PlatformColor } from 'react-native'
 
 type ColorKeys =
   | 'MainView'
@@ -25,45 +25,17 @@ const ios: Theme = {
   Dev: PlatformColor( 'systemRed' ),
 }
 
-const androidPalette = {
-  p0: '#ffffff',
-  p50: '#f5f5f5',
-  p100: '#e9e9e9',
-  p200: '#d9d9d9',
-  p300: '#c4c4c4',
-  p400: '#9d9d9d',
-  p500: '#7b7b7b',
-  p600: '#555555',
-  p700: '#434343',
-  p800: '#262626',
-  p900: '#000000',
-}
-
-const androidLight: Theme = {
-  MainView: androidPalette.p0,
-  ModalSheet: androidPalette.p50,
-  ModalSheetTitleBar: androidPalette.p50,
-  InputBox: androidPalette.p100,
-  Separator: androidPalette.p200,
-  Disabled: androidPalette.p300,
-  PrimaryText: androidPalette.p900,
-  SecondaryText: androidPalette.p500,
-  Dev: PlatformColor( '@android:color/holo_red_light' ),
-}
-
-const androidDark: Theme = {
-  MainView: androidPalette.p900,
-  ModalSheet: androidPalette.p800,
-  ModalSheetTitleBar: androidPalette.p800,
-  InputBox: androidPalette.p700,
-  Separator: androidPalette.p700,
-  Disabled: androidPalette.p700,
-  PrimaryText: androidPalette.p100,
-  SecondaryText: androidPalette.p400,
+const android: Theme = {
+  MainView: PlatformColor( '?android:attr/colorForegroundInverse' ),
+  ModalSheet: PlatformColor( '?android:attr/colorPrimary' ),
+  ModalSheetTitleBar: PlatformColor( '?android:attr/colorPrimary' ),
+  InputBox: PlatformColor( '?android:attr/colorButtonNormal' ),
+  Separator: '#808080',
+  Disabled: '#808080',
+  PrimaryText: PlatformColor( '?android:attr/colorForeground' ),
+  SecondaryText: '#808080',
   Dev: PlatformColor( '@android:color/holo_red_dark' ),
 }
-
-const android = Appearance.getColorScheme() === 'light' ? androidLight : androidDark
 
 const Colors = Platform.select<Theme>( { android, ios } )!
 

--- a/src/themes/colors.ts
+++ b/src/themes/colors.ts
@@ -65,6 +65,6 @@ const androidDark: Theme = {
 
 const android = Appearance.getColorScheme() === 'light' ? androidLight : androidDark
 
-const Colors = Platform.select<Theme>( { android, ios } )
+const Colors = Platform.select<Theme>( { android, ios } )!
 
 export default Colors

--- a/src/themes/colors.ts
+++ b/src/themes/colors.ts
@@ -1,13 +1,70 @@
-enum Colors {
-  MainView = '#000',
-  ModalSheet = '#1A1A1A',
-  ModalSheetTitleBar = '#242424',
-  InputBox = '#3C3C3C',
-  Separator = '#3C3C3C',
-  Disabled = '#3C3C3C',
-  PrimaryText = '#FFF',
-  SecondaryText = '#8A8A8A',
-  Dev = '#FF0000',
+import { Appearance, OpaqueColorValue, Platform, PlatformColor } from 'react-native'
+
+type ColorKeys =
+  | 'MainView'
+  | 'ModalSheet'
+  | 'ModalSheetTitleBar'
+  | 'InputBox'
+  | 'Separator'
+  | 'Disabled'
+  | 'PrimaryText'
+  | 'SecondaryText'
+  | 'Dev'
+
+type Theme = { [key in ColorKeys]: OpaqueColorValue | string }
+
+const ios: Theme = {
+  MainView: PlatformColor( 'systemBackground' ),
+  ModalSheet: PlatformColor( 'secondarySystemBackground' ),
+  ModalSheetTitleBar: PlatformColor( 'tertiarySystemBackground' ),
+  InputBox: PlatformColor( 'secondarySystemBackground' ),
+  Separator: PlatformColor( 'separator' ),
+  Disabled: PlatformColor( 'systemFill' ),
+  PrimaryText: PlatformColor( 'label' ),
+  SecondaryText: PlatformColor( 'secondaryLabel' ),
+  Dev: PlatformColor( 'systemRed' ),
 }
+
+const androidPalette = {
+  p0: '#ffffff',
+  p50: '#f5f5f5',
+  p100: '#e9e9e9',
+  p200: '#d9d9d9',
+  p300: '#c4c4c4',
+  p400: '#9d9d9d',
+  p500: '#7b7b7b',
+  p600: '#555555',
+  p700: '#434343',
+  p800: '#262626',
+  p900: '#000000',
+}
+
+const androidLight: Theme = {
+  MainView: androidPalette.p0,
+  ModalSheet: androidPalette.p50,
+  ModalSheetTitleBar: androidPalette.p50,
+  InputBox: androidPalette.p100,
+  Separator: androidPalette.p200,
+  Disabled: androidPalette.p300,
+  PrimaryText: androidPalette.p900,
+  SecondaryText: androidPalette.p500,
+  Dev: PlatformColor( '@android:color/holo_red_light' ),
+}
+
+const androidDark: Theme = {
+  MainView: androidPalette.p900,
+  ModalSheet: androidPalette.p800,
+  ModalSheetTitleBar: androidPalette.p800,
+  InputBox: androidPalette.p700,
+  Separator: androidPalette.p700,
+  Disabled: androidPalette.p700,
+  PrimaryText: androidPalette.p100,
+  SecondaryText: androidPalette.p400,
+  Dev: PlatformColor( '@android:color/holo_red_dark' ),
+}
+
+const android = Appearance.getColorScheme() === 'light' ? androidLight : androidDark
+
+const Colors = Platform.select<Theme>( { android, ios } )
 
 export default Colors

--- a/src/themes/colors.ts
+++ b/src/themes/colors.ts
@@ -1,4 +1,4 @@
-import { Appearance, OpaqueColorValue, Platform, PlatformColor } from 'react-native'
+import { Appearance, ColorValue, Platform, PlatformColor } from 'react-native'
 
 type ColorKeys =
   | 'MainView'
@@ -11,7 +11,7 @@ type ColorKeys =
   | 'SecondaryText'
   | 'Dev'
 
-type Theme = { [key in ColorKeys]: OpaqueColorValue | string }
+type Theme = { [key in ColorKeys]: ColorValue }
 
 const ios: Theme = {
   MainView: PlatformColor( 'systemBackground' ),

--- a/src/themes/gradients.ts
+++ b/src/themes/gradients.ts
@@ -1,15 +1,13 @@
 import { Appearance } from 'react-native'
 
-import Colors from './colors'
-
 /**
  * The gradients are very specific to the consumption of react-native-linear-gradient.
  */
 export const gradients = {
   TransparentToBlack: {
     colors: Appearance.getColorScheme() === 'light'
-      ? [ 'rgba(255, 255, 255, 0)', Colors.MainView ]
-      : [ 'rgba(0, 0, 0, 0)', Colors.MainView ],
+      ? [ 'rgba(255, 255, 255, 0)', 'rgba(255, 255, 255, 1)' ]
+      : [ 'rgba(0, 0, 0, 0)', 'rgba(0, 0, 0, 1)' ],
     locations: [ 0.0, 0.6 ],
   },
 }

--- a/src/themes/gradients.ts
+++ b/src/themes/gradients.ts
@@ -1,9 +1,15 @@
+import { Appearance } from 'react-native'
+
+import Colors from './colors'
+
 /**
  * The gradients are very specific to the consumption of react-native-linear-gradient.
  */
 export const gradients = {
   TransparentToBlack: {
-    colors: [ 'rgba(0, 0, 0, 0)', 'rgba(0, 0, 0, 1)' ],
+    colors: Appearance.getColorScheme() === 'light'
+      ? [ 'rgba(255, 255, 255, 0)', Colors.MainView ]
+      : [ 'rgba(0, 0, 0, 0)', Colors.MainView ],
     locations: [ 0.0, 0.6 ],
   },
 }

--- a/src/themes/gradients.ts
+++ b/src/themes/gradients.ts
@@ -4,7 +4,7 @@ import { Appearance } from 'react-native'
  * The gradients are very specific to the consumption of react-native-linear-gradient.
  */
 export const gradients = {
-  TransparentToBlack: {
+  TransparentToBackground: {
     colors: Appearance.getColorScheme() === 'light'
       ? [ 'rgba(255, 255, 255, 0)', 'rgba(255, 255, 255, 1)' ]
       : [ 'rgba(0, 0, 0, 0)', 'rgba(0, 0, 0, 1)' ],


### PR DESCRIPTION
<!-- Please title as if this PR were a single commit to our main branch. -->
<!-- https://docs.shabados.com/community/coding-guidelines#commit-messages -->
<!-- Also don't forget to add any reviewer(s) and link the related issue! -->

### Summary
This PR aims to use system colors when possible. Android is still WIP according to RN team. Here are two issues to track for that:

- [PlatformColor returning 0 on Android](https://github.com/facebook/react-native/issues/29763) 
- [Android not updating based on OS/System setting of dark/light](https://github.com/facebook/react-native/issues/32823)

### Issues
- [ ] Android only uses the correct them on launch. If the user changes the theme (or it automatically changes based on time of day), the app will not react to reflect it.
- [ ] The transparency of the bottom bar requires the correct RGB values to do a proper gradient. This is also only set once on launch. So if the device switches dark/light modes, the bottom bar transparency will get messed up. This applies to iOS and Android.
- [x] Not related to the current PR/issue, but I've noticed the following:
  - The scrollbar on the right hand side goes behind the bottom bar, therefore the gradient is overlaid on top of the scrollbar.
  - The scroll to end effect on Android (showing a semi-circle) is also covered by this bottom bar gradient, and looks a bit odd.
  - It might be best to treat the bottom bar as a separate bar and to adjust the height of main content view accordingly.
- [x] Lastly, there is a linting error I don't know how to resolve (besides doing something like `Colors?.MainView`): 
![image](https://user-images.githubusercontent.com/14130567/150440482-444d341c-124c-4ea8-b641-eeab0c8f0728.png)

### Screenshots

![image](https://user-images.githubusercontent.com/14130567/150450986-7bc96b76-c92f-4f4d-a691-1c14aeb6712f.png)

![image](https://user-images.githubusercontent.com/14130567/150451249-3ece6830-6e1a-48a6-9f98-5b18a6f8b55b.png)

![image](https://user-images.githubusercontent.com/14130567/150451569-fe33887a-98fc-4566-b53b-e35fb64e8940.png)

![image](https://user-images.githubusercontent.com/14130567/150451635-fc50ad83-b5c7-4be2-a677-972b046913c7.png)


### Duration
3 hours. 2 of which were mostly due to Android troubles.