### PR TITLE
feat: add Jotai and React Suspense

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,6 +6,7 @@ module.exports = {
     // metro-react-native-babel-preset includes this plugin, but with runtime: 'classic' by default
     // https://github.com/facebook/metro/issues/646#issuecomment-799174473
     [ '@babel/plugin-transform-react-jsx', { runtime: 'automatic' } ],
+    'react-native-reanimated/plugin',
   ],
   env: {
     production: {

--- a/ios/Mobile.xcodeproj/project.pbxproj
+++ b/ios/Mobile.xcodeproj/project.pbxproj
@@ -668,7 +668,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -734,7 +734,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -369,7 +369,7 @@ PODS:
     - React-Core
   - RNGestureHandler (1.10.3):
     - React-Core
-  - RNReanimated (2.2.4):
+  - RNReanimated (2.3.1):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -395,7 +395,6 @@ PODS:
     - React-RCTNetwork
     - React-RCTSettings
     - React-RCTText
-    - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
   - RNScreens (3.9.0):
@@ -619,7 +618,7 @@ SPEC CHECKSUMS:
   React-jsinspector: d9c8eb0b53f0da206fed56612b289fec84991157
   React-logger: e522e76fa3e9ec3e7d7115b49485cc065cf4ae06
   react-native-config: 6502b1879f97ed5ac570a029961fc35ea606cd14
-  react-native-safe-area-context: 5cf05f49df9d17261e40e518481f2e334c6cd4b5
+  react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
   React-perflogger: 73732888d37d4f5065198727b167846743232882
   React-RCTActionSheet: 96c6d774fa89b1f7c59fc460adc3245ba2d7fd79
   React-RCTAnimation: 8940cfd3a8640bd6f6372150dbdb83a79bcbae6c
@@ -632,14 +631,14 @@ SPEC CHECKSUMS:
   React-RCTVibration: 50cfe7049167cfc7e83ac5542c6fff0c76791a9b
   React-runtimeexecutor: bbbdb3d8fcf327c6e2249ee71b6ef1764b7dc266
   ReactCommon: 9bac022ab71596f2b0fde1268272543184c63971
-  RNCMaskedView: f127cd9652acfa31b91dcff613e07ba18b774db6
-  RNDeviceInfo: 417b2ef4456c13a9d50ad8c57895eea837b735a8
+  RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
+  RNDeviceInfo: 0400a6d0c94186d1120c3cbd97b23abc022187a9
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
-  RNReanimated: 65583befd5706cc9c86ae9a081786181ced37b93
+  RNReanimated: da3860204e5660c0dd66739936732197d359d753
   RNScreens: 4d79118be80f79fa1f4aa131909a1d6e86280af3
-  RNSplit: b8c8a83160e75a324ef7949f28f4d4d8a812142b
+  RNSplit: e75dc5a74f4c0e34bec2b68a6d075cbd8aadbe48
   RNVectorIcons: 4143ba35feebab8fdbe6bc43d1e776b393d47ac8
-  toolbar-android: 7c528a58a3d79f03124cbb370f738280bf1114a6
+  toolbar-android: 2a73856e98b750d7e71ce4644d3f41cc98211719
   Yoga: 32a18c0e845e185f4a2a66ec76e1fd1f958f22fa
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "env-var": "^7.1.1",
         "gurmukhi-utils": "^3.2.1",
         "i18next": "^21.5.3",
+        "jotai": "^1.5.3",
         "lodash": "^4.17.21",
         "react": "^17.0.2",
         "react-i18next": "^11.14.3",
@@ -12481,6 +12482,55 @@
         "@sideway/address": "^4.1.0",
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-1.5.3.tgz",
+      "integrity": "sha512-iD8MkbehxTjfRUtIJJdyQcjbAe2MqjW1+oFc5lvfgRjLHwjRQyWnZC3gdGAOQCOqUSPZHOBGgWyP/8gBDckaNQ==",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*",
+        "@babel/template": "*",
+        "@urql/core": "*",
+        "immer": "*",
+        "optics-ts": "*",
+        "react": ">=16.8",
+        "react-query": "*",
+        "valtio": "*",
+        "wonka": "*",
+        "xstate": "*"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@babel/template": {
+          "optional": true
+        },
+        "@urql/core": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "optics-ts": {
+          "optional": true
+        },
+        "react-query": {
+          "optional": true
+        },
+        "valtio": {
+          "optional": true
+        },
+        "wonka": {
+          "optional": true
+        },
+        "xstate": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-sha3": {
@@ -26901,6 +26951,12 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "jotai": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-1.5.3.tgz",
+      "integrity": "sha512-iD8MkbehxTjfRUtIJJdyQcjbAe2MqjW1+oFc5lvfgRjLHwjRQyWnZC3gdGAOQCOqUSPZHOBGgWyP/8gBDckaNQ==",
+      "requires": {}
     },
     "js-sha3": {
       "version": "0.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react": "^17.0.2",
         "react-i18next": "^11.14.3",
         "react-native": "^0.66.3",
+        "react-native-animated-spinkit": "^1.5.2",
         "react-native-config": "^1.4.5",
         "react-native-device-info": "^8.4.8",
         "react-native-gesture-handler": "^1.10.3",
@@ -14894,6 +14895,15 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-native-animated-spinkit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/react-native-animated-spinkit/-/react-native-animated-spinkit-1.5.2.tgz",
+      "integrity": "sha512-YCQGR3HzEQvyaAnepiyf/hv88Sta3UIZ2CFZPtFqwu+VbFJfMgjJZniOx4157TuR5AAYajEJP9Fgy+JLIU3jzQ==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-codegen": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.0.7.tgz",
@@ -15024,14 +15034,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-spinkit": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/react-native-spinkit/-/react-native-spinkit-1.5.1.tgz",
-      "integrity": "sha512-XkTgP4e+/MZpbI1GdZTIEQ+6WeMWQT4duWnSiXaaVW7py0rtaBLswtAEA6uXQGUhnxMnPWZhbLz7QponpH3ciQ==",
-      "dependencies": {
-        "prop-types": "^15.5.8"
       }
     },
     "node_modules/react-native-vector-icons": {
@@ -28842,6 +28844,12 @@
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         }
       }
+    },
+    "react-native-animated-spinkit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/react-native-animated-spinkit/-/react-native-animated-spinkit-1.5.2.tgz",
+      "integrity": "sha512-YCQGR3HzEQvyaAnepiyf/hv88Sta3UIZ2CFZPtFqwu+VbFJfMgjJZniOx4157TuR5AAYajEJP9Fgy+JLIU3jzQ==",
+      "requires": {}
     },
     "react-native-codegen": {
       "version": "0.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "react-native-device-info": "^8.4.8",
         "react-native-gesture-handler": "^1.10.3",
         "react-native-linear-gradient": "^2.5.6",
-        "react-native-reanimated": "^2.2.4",
+        "react-native-reanimated": "^2.3.1",
         "react-native-safe-area-context": "^3.3.2",
         "react-native-screens": "^3.9.0",
         "react-native-vector-icons": "^9.0.0",
@@ -4574,6 +4574,11 @@
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
       "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ=="
+    },
+    "node_modules/@types/invariant": {
+      "version": "2.2.35",
+      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.35.tgz",
+      "integrity": "sha512-DxX1V9P8zdJPYQat1gHyY0xj3efl8gnMVjiM9iCY6y27lj+PoQWkgjt8jDqmovPqULkKVpKRg8J36iQiA+EtEg=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -14981,34 +14986,22 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.2.4.tgz",
-      "integrity": "sha512-Nn648MfEEnTCEiWsl1YmfkojiLyV0NMY0EiRdDRbZNfJVfxBuyqhCxI/4Jd7aBi162qpgf8XK2mByYgvF4zLrQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.3.1.tgz",
+      "integrity": "sha512-nzjVqwkB8eeyPKT2KoiA9EEz17ZMFSGMoOTC17Z9b5nE2Z4ZHjHM5EKhY0TlwzXFUuJAE9PhOfxF0wIO/maZSA==",
       "dependencies": {
         "@babel/plugin-transform-object-assign": "^7.10.4",
-        "fbjs": "^3.0.0",
+        "@types/invariant": "^2.2.35",
+        "invariant": "^2.2.4",
+        "lodash.isequal": "^4.5.0",
         "mockdate": "^3.0.2",
+        "react-native-screens": "^3.4.0",
         "string-hash-64": "^1.0.3"
       },
       "peerDependencies": {
         "react": "*",
         "react-native": "*",
         "react-native-gesture-handler": "*"
-      }
-    },
-    "node_modules/react-native-reanimated/node_modules/fbjs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.1.tgz",
-      "integrity": "sha512-8+vkGyT4lNDRKHQNPp0yh/6E7FfkLg89XqQbOYnvntRh+8RiSD43yrh9E5ejp1muCizTL4nDVG+y8W4e+LROHg==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-fetch": "^3.0.4",
-        "fbjs-css-vars": "^1.0.0",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.30"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -15031,6 +15024,14 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-spinkit": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-spinkit/-/react-native-spinkit-1.5.1.tgz",
+      "integrity": "sha512-XkTgP4e+/MZpbI1GdZTIEQ+6WeMWQT4duWnSiXaaVW7py0rtaBLswtAEA6uXQGUhnxMnPWZhbLz7QponpH3ciQ==",
+      "dependencies": {
+        "prop-types": "^15.5.8"
       }
     },
     "node_modules/react-native-vector-icons": {
@@ -20706,6 +20707,11 @@
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
       "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ=="
+    },
+    "@types/invariant": {
+      "version": "2.2.35",
+      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.35.tgz",
+      "integrity": "sha512-DxX1V9P8zdJPYQat1gHyY0xj3efl8gnMVjiM9iCY6y27lj+PoQWkgjt8jDqmovPqULkKVpKRg8J36iQiA+EtEg=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -27681,7 +27687,6 @@
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.66.2.tgz",
       "integrity": "sha512-H/nLBAz0MgfDloSe1FjyH4EnbokHFdncyERvLPXDACY3ROVRCeUyFNo70ywRGXW2NMbrV4H7KUyU4zkfWhC2HQ==",
       "requires": {
-        "@babel/core": "^7.14.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -27728,7 +27733,6 @@
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.66.2.tgz",
       "integrity": "sha512-z1ab7ihIT0pJrwgi9q2IH+LcW/xUWMQ0hH+Mrk7wbKQB0RnJdXFoxphrfoVHBHMUu+TBPetUcEkKawkK1e7Cng==",
       "requires": {
-        "@babel/core": "^7.14.0",
         "babel-preset-fbjs": "^3.4.0",
         "hermes-parser": "0.4.7",
         "metro-babel-transformer": "0.66.2",
@@ -28914,30 +28918,17 @@
       }
     },
     "react-native-reanimated": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.2.4.tgz",
-      "integrity": "sha512-Nn648MfEEnTCEiWsl1YmfkojiLyV0NMY0EiRdDRbZNfJVfxBuyqhCxI/4Jd7aBi162qpgf8XK2mByYgvF4zLrQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.3.1.tgz",
+      "integrity": "sha512-nzjVqwkB8eeyPKT2KoiA9EEz17ZMFSGMoOTC17Z9b5nE2Z4ZHjHM5EKhY0TlwzXFUuJAE9PhOfxF0wIO/maZSA==",
       "requires": {
         "@babel/plugin-transform-object-assign": "^7.10.4",
-        "fbjs": "^3.0.0",
+        "@types/invariant": "^2.2.35",
+        "invariant": "^2.2.4",
+        "lodash.isequal": "^4.5.0",
         "mockdate": "^3.0.2",
+        "react-native-screens": "^3.4.0",
         "string-hash-64": "^1.0.3"
-      },
-      "dependencies": {
-        "fbjs": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.1.tgz",
-          "integrity": "sha512-8+vkGyT4lNDRKHQNPp0yh/6E7FfkLg89XqQbOYnvntRh+8RiSD43yrh9E5ejp1muCizTL4nDVG+y8W4e+LROHg==",
-          "requires": {
-            "cross-fetch": "^3.0.4",
-            "fbjs-css-vars": "^1.0.0",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.30"
-          }
-        }
       }
     },
     "react-native-safe-area-context": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react": "^17.0.2",
     "react-i18next": "^11.14.3",
     "react-native": "^0.66.3",
+    "react-native-animated-spinkit": "^1.5.2",
     "react-native-config": "^1.4.5",
     "react-native-device-info": "^8.4.8",
     "react-native-gesture-handler": "^1.10.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-native-device-info": "^8.4.8",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-linear-gradient": "^2.5.6",
-    "react-native-reanimated": "^2.2.4",
+    "react-native-reanimated": "^2.3.1",
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.9.0",
     "react-native-vector-icons": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "env-var": "^7.1.1",
     "gurmukhi-utils": "^3.2.1",
     "i18next": "^21.5.3",
+    "jotai": "^1.5.3",
     "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-i18next": "^11.14.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { NavigationContainer } from '@react-navigation/native'
 import { createStackNavigator, StackNavigationOptions } from '@react-navigation/stack'
+import { Suspense } from 'react'
 
+import DefaultFallback from './components/DefaultFallback'
 import withContexts from './components/with-contexts'
 import { collectionsScreen } from './screens/Collections'
 import { gurbaniScreen } from './screens/Gurbani'
@@ -14,13 +16,15 @@ const screens = [ gurbaniScreen, searchScreen, collectionsScreen ]
 const defaultScreenOptions: StackNavigationOptions = { presentation: 'modal' }
 
 const App = () => (
-  <NavigationContainer>
-    <Navigator>
-      <Group screenOptions={defaultScreenOptions}>
-        {screens.map( ( options ) => <Screen key={options.name} {...options} /> )}
-      </Group>
-    </Navigator>
-  </NavigationContainer>
+  <Suspense fallback={<DefaultFallback />}>
+    <NavigationContainer>
+      <Navigator>
+        <Group screenOptions={defaultScreenOptions}>
+          {screens.map( ( options ) => <Screen key={options.name} {...options} /> )}
+        </Group>
+      </Navigator>
+    </NavigationContainer>
+  </Suspense>
 )
 
 export default () => withContexts( <App /> )

--- a/src/components/DefaultFallback.tsx
+++ b/src/components/DefaultFallback.tsx
@@ -1,0 +1,20 @@
+import { ActivityIndicator, StyleSheet } from 'react-native'
+
+import Colors from '../themes/colors'
+import Container from './Container'
+
+const styles = StyleSheet.create( {
+  root: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+} )
+
+const DefaultFallback = () => (
+  <Container style={styles.root}>
+    <ActivityIndicator size="large" color={Colors.PrimaryText} />
+  </Container>
+)
+
+export default DefaultFallback

--- a/src/components/DefaultFallback.tsx
+++ b/src/components/DefaultFallback.tsx
@@ -1,4 +1,5 @@
-import { ActivityIndicator, StyleSheet } from 'react-native'
+import { StyleSheet } from 'react-native'
+import { Pulse } from 'react-native-animated-spinkit'
 
 import Colors from '../themes/colors'
 import Container from './Container'
@@ -13,7 +14,7 @@ const styles = StyleSheet.create( {
 
 const DefaultFallback = () => (
   <Container style={styles.root}>
-    <ActivityIndicator size="large" color={Colors.PrimaryText} />
+    <Pulse color={Colors.PrimaryText} />
   </Container>
 )
 

--- a/src/components/with-contexts.tsx
+++ b/src/components/with-contexts.tsx
@@ -1,3 +1,4 @@
+import { Provider } from 'jotai'
 import { ElementType } from 'react'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
@@ -8,6 +9,7 @@ export const queryClient = new QueryClient( {
 } )
 
 const contexts: [ElementType, { [k: string]: any }?][] = [
+  [ Provider ],
   [ QueryClientProvider, { client: queryClient } ],
 ]
 

--- a/src/components/with-contexts.tsx
+++ b/src/components/with-contexts.tsx
@@ -1,7 +1,11 @@
 import { ElementType } from 'react'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
-export const queryClient = new QueryClient()
+export const queryClient = new QueryClient( {
+  defaultOptions: {
+    queries: { suspense: true },
+  },
+} )
 
 const contexts: [ElementType, { [k: string]: any }?][] = [
   [ QueryClientProvider, { client: queryClient } ],

--- a/src/screens/Collections/index.int.spec.tsx
+++ b/src/screens/Collections/index.int.spec.tsx
@@ -2,6 +2,7 @@ import { NavigationContainer } from '@react-navigation/native'
 import { createStackNavigator } from '@react-navigation/stack'
 import { fireEvent, render, waitForElementToBeRemoved } from '@testing-library/react-native'
 import { toUnicode } from 'gurmukhi-utils'
+import { Suspense } from 'react'
 import { Text } from 'react-native'
 
 import * as factories from '../../../test/factories'
@@ -17,14 +18,17 @@ const setup = async ( data: CollectionData[] ) => {
   const { Navigator, Screen } = createStackNavigator<AppStackParams>()
 
   const queries = render( withContexts(
-    <NavigationContainer>
-      <Navigator>
-        <Screen {...collectionsScreen} />
-        <Screen name={Screens.Gurbani}>
-          {( { route: { params: { id } } } ) => <Text>{id}</Text>}
-        </Screen>
-      </Navigator>
-    </NavigationContainer>,
+    <Suspense fallback={<Text>Loading</Text>}>
+      <NavigationContainer>
+        <Navigator>
+          <Screen {...collectionsScreen} />
+          <Screen name={Screens.Gurbani}>
+            {( { route: { params: { id } } } ) => <Text>{id}</Text>}
+          </Screen>
+        </Navigator>
+      </NavigationContainer>
+      ,
+    </Suspense>,
   ) )
 
   const { getByText } = queries

--- a/src/screens/Gurbani/Line.tsx
+++ b/src/screens/Gurbani/Line.tsx
@@ -1,5 +1,6 @@
 import { toUnicode } from 'gurmukhi-utils'
-import { StyleSheet, View } from 'react-native'
+import { StyleSheet } from 'react-native'
+import Animated, { FadeInRight } from 'react-native-reanimated'
 
 import Typography from '../../components/Typography'
 import Languages from '../../helpers/languages'
@@ -69,7 +70,7 @@ const Line = ( {
   const fontSizeStyle = getGurmukhiFontStyle( useFeatureStatus( 'gurmukhi_font_size' ) )
 
   return (
-    <View style={styles.root}>
+    <Animated.View style={styles.root} entering={FadeInRight}>
       <Typography style={[ styles.gurbani, fontSizeStyle ]}>{toUnicode( gurmukhi )}</Typography>
 
       {transliterations.map( ( language ) => (
@@ -91,7 +92,7 @@ const Line = ( {
             {translation}
           </Typography>
         ) )}
-    </View>
+    </Animated.View>
   )
 }
 

--- a/src/screens/Gurbani/index.int.spec.tsx
+++ b/src/screens/Gurbani/index.int.spec.tsx
@@ -2,6 +2,8 @@ import { NavigationContainer } from '@react-navigation/native'
 import { createStackNavigator } from '@react-navigation/stack'
 import { render } from '@testing-library/react-native'
 import { toUnicode } from 'gurmukhi-utils'
+import { Suspense } from 'react'
+import { Text } from 'react-native'
 
 import * as factories from '../../../test/factories'
 import withContexts from '../../components/with-contexts'
@@ -15,20 +17,22 @@ const setup = ( shabad = factories.shabad.build() ) => {
   jest.spyOn( shabads, 'getShabad' ).mockResolvedValue( shabad )
 
   return render( withContexts(
-    <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen {...gurbaniScreen} />
-      </Stack.Navigator>
-    </NavigationContainer>,
+    <Suspense fallback={<Text>Loading</Text>}>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen {...gurbaniScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </Suspense>,
   ) )
 }
 
 describe( '<GurbaniScreen />', () => {
   describe( 'on mount', () => {
-    it( 'should render a bottom bar', () => {
-      const { getByPlaceholderText } = setup()
+    it( 'should render a bottom bar', async () => {
+      const { findByPlaceholderText } = setup()
 
-      expect( getByPlaceholderText( 'Search' ) ).toBeTruthy()
+      expect( await findByPlaceholderText( 'Search' ) ).toBeTruthy()
     } )
 
     it( 'should load and render a target shabad', async () => {

--- a/src/screens/Gurbani/index.tsx
+++ b/src/screens/Gurbani/index.tsx
@@ -29,7 +29,7 @@ const GurbaniScreen = ( {
 
   return (
     <Container>
-      {data && <Lines lines={data.lines} />}
+      <Lines lines={data!.lines} />
 
       <BottomBar />
     </Container>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "exclude": ["node_modules", "android", "ios", "coverage", "docs"]
 }


### PR DESCRIPTION
## Summary

This PR adds Jotai, which requires React Suspense.

I went into a little rabit hole here:
- Switched on React Suspense in react-query
- Added a default fallback loading screen for the app with `react-native-animated-spinkit`, although that commit is entirely revertable if we prefer `ActivityIndicator` (imho looks shoddy on iOS)
- [Unrelated] Added a (imo) nice fade in transition, enabled by a `react-native-reanimated` upgrade. This was more a PoC to understand the complexity behind animations in react native. This library really does make some things a lot easier.
- Installed Jotai and added the root Provider context required
