### PR TITLE
fix: minimize gap of safe area view

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react'
-import { ColorValue, StatusBar, StyleSheet, View } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { ColorValue, SafeAreaView, StatusBar, StyleSheet, View } from 'react-native'
 
 import Colors from '../themes/colors'
 import Units from '../themes/units'
@@ -55,7 +54,7 @@ const Navbar = ( {
 }: NavbarProps ) => (
   <View style={[ { backgroundColor } ]}>
     <StatusBar />
-    <SafeAreaView edges={[ 'left', 'top', 'right' ]} />
+    <SafeAreaView />
 
     <View style={styles.header}>
       <View style={styles.liftUp}>

--- a/src/screens/Gurbani/BottomBar.tsx
+++ b/src/screens/Gurbani/BottomBar.tsx
@@ -1,8 +1,7 @@
 import { useNavigation } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
-import { Pressable, StyleSheet, View } from 'react-native'
+import { Pressable, SafeAreaView, StyleSheet, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
-import { SafeAreaView } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 
 import Button from '../../components/Button'
@@ -45,7 +44,7 @@ const BottomBar = () => {
   const onCollectionsPress = () => navigation.navigate( Screens.Collections )
 
   return (
-    <SafeAreaView edges={[ 'bottom', 'left', 'right' ]}>
+    <SafeAreaView>
       <LinearGradient
         style={styles.background}
         locations={gradients.TransparentToBackground.locations}


### PR DESCRIPTION
<!-- Please title as if this PR were a single commit to our main branch. -->
<!-- https://docs.shabados.com/community/coding-guidelines#commit-messages -->
<!-- Also don't forget to add any reviewer(s) and link the related issue! -->

### Summary
The built-in safeareaview is doing a better job than the third party bundled with react navigation.

<img src="https://user-images.githubusercontent.com/14130567/151741503-359c8213-3aea-479d-bc6e-06a4380c25ad.png" width="320"/>

### Test
- working on iPhone 8 and 11
- cannot uninstall bundled `react-native-safe-area-context` as `@react-navigation` is depending on it.
- may want to look into [react-native-navigation](https://github.com/wix/react-native-navigation), a native navigation solution (might also fix issues such as #189 ?)

### Duration
- 1 hour