### PR TITLE
feat: add tablet support

### DIFF
--- a/ios/Mobile.xcodeproj/project.pbxproj
+++ b/ios/Mobile.xcodeproj/project.pbxproj
@@ -616,6 +616,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.shabados.app";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -646,6 +647,7 @@
 				PRODUCT_NAME = "Shabad OS";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.shabados.app";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/ios/Mobile/Info.plist
+++ b/ios/Mobile/Info.plist
@@ -81,6 +81,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "cross-env ENVFILE=config/.env.local jest --color",
     "start:android": "cross-env ENVFILE=config/.env.local react-native run-android",
     "start:ios": "cross-env ENVFILE=config/.env.local react-native run-ios --simulator='iPhone 12'",
-    "start:ipad": "cross-env ENVFILE=config/.env.local react-native run-ios --simulator='iPad (9th generation)'",
+    "start:ios:ipad": "cross-env ENVFILE=config/.env.local react-native run-ios --simulator='iPad (9th generation)'",
     "build:android": "bundle exec fastlane android build",
     "build:ios": "bundle exec fastlane ios build",
     "clean:android": "bundle exec fastlane android clean",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "cross-env ENVFILE=config/.env.local jest --color",
     "start:android": "cross-env ENVFILE=config/.env.local react-native run-android",
     "start:ios": "cross-env ENVFILE=config/.env.local react-native run-ios --simulator='iPhone 12'",
+    "start:ipad": "cross-env ENVFILE=config/.env.local react-native run-ios --simulator='iPad (9th generation)'",
     "build:android": "bundle exec fastlane android build",
     "build:ios": "bundle exec fastlane ios build",
     "clean:android": "bundle exec fastlane android clean",

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -4,7 +4,7 @@ import { StyleSheet } from 'react-native'
 
 const styles = StyleSheet.create( {
   native: {
-    margin: -16,
+    marginLeft: -8,
   },
 } )
 

--- a/src/components/IconHeaderButton.tsx
+++ b/src/components/IconHeaderButton.tsx
@@ -1,26 +1,15 @@
-import { StyleSheet } from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import { HeaderButton } from 'react-navigation-header-buttons'
 
 import Colors from '../themes/colors'
 
-const styles = StyleSheet.create( {
-  native: {
-    margin: 0,
-  },
-} )
-
 export type IconHeaderButtonProps = {
   title: string,
   disabled?: boolean,
-  // To fix https://github.com/react-navigation/react-navigation/issues/10058
-  // Native Stack Navigators + HeaderBackButton has funky margin otherwise
-  native?: boolean,
 }
 
-const IconHeaderButton = ( { disabled, native = true, ...props }: IconHeaderButtonProps ) => (
+const IconHeaderButton = ( { disabled, ...props }: IconHeaderButtonProps ) => (
   <HeaderButton
-    style={native && styles.native}
     IconComponent={Icon}
     iconSize={28}
     color={( disabled ? Colors.Disabled : Colors.PrimaryText ) as string}

--- a/src/components/IconHeaderButton.tsx
+++ b/src/components/IconHeaderButton.tsx
@@ -6,7 +6,7 @@ import Colors from '../themes/colors'
 
 const styles = StyleSheet.create( {
   native: {
-    margin: -16,
+    margin: 0,
   },
 } )
 

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,33 @@
+import { Image, StyleSheet, useWindowDimensions, View } from 'react-native'
+
+import logo from '../../assets/images/logo.png'
+import Typography from './Typography'
+
+const styles = StyleSheet.create( {
+  headerTitle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  logoIcon: {
+    width: 28,
+    height: 28,
+    marginRight: 6.5,
+  },
+  logoText: {
+    fontSize: 20,
+    lineHeight: 24,
+    fontWeight: '300',
+  },
+} )
+
+const Logo = () => {
+  const { width } = useWindowDimensions()
+  return (
+    <View style={styles.headerTitle}>
+      <Image style={styles.logoIcon} source={logo} />
+      {width > 350 && <Typography style={styles.logoText}>Shabad OS</Typography>}
+    </View>
+  )
+}
+
+export default Logo

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -22,6 +22,7 @@ const styles = StyleSheet.create( {
 
 const Logo = () => {
   const { width } = useWindowDimensions()
+
   return (
     <View style={styles.headerTitle}>
       <Image style={styles.logoIcon} source={logo} />

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,6 +1,7 @@
 import { Image, StyleSheet, useWindowDimensions, View } from 'react-native'
 
 import logo from '../../assets/images/logo.png'
+import Units from '../themes/units'
 import Typography from './Typography'
 
 const styles = StyleSheet.create( {
@@ -26,7 +27,8 @@ const Logo = () => {
   return (
     <View style={styles.headerTitle}>
       <Image style={styles.logoIcon} source={logo} />
-      {width > 350 && <Typography style={styles.logoText}>Shabad OS</Typography>}
+      {width > Units.ThinSplitViewWidth
+      && <Typography style={styles.logoText}>Shabad OS</Typography>}
     </View>
   )
 }

--- a/src/components/ModalSheet.tsx
+++ b/src/components/ModalSheet.tsx
@@ -56,7 +56,7 @@ const ModalSheet = ( {
   children,
 }: ModalSheetProps ) => {
   const { isLandscape, landscapeStyle } = useLandscape()
-  const snapPoints = isLandscape ? [ '70%', '90%' ] : [ '40%', '70%' ]
+  const snapPoints = isLandscape ? [ '75%', '98%' ] : [ '40%', '75%' ]
 
   const sheetRef = useRef<BottomSheetModal>( null )
 

--- a/src/components/use-landscape.spec.tsx
+++ b/src/components/use-landscape.spec.tsx
@@ -31,8 +31,8 @@ describe( 'useLandscape()', () => {
       const { result: { current } } = setup( true )
 
       expect( current.landscapeStyle ).toMatchObject( {
-        marginRight: SHORTER_EDGE / 2,
-        marginLeft: SHORTER_EDGE / 2,
+        marginRight: LONGER_EDGE / 6,
+        marginLeft: LONGER_EDGE / 6,
       } )
     } )
   } )

--- a/src/components/use-landscape.tsx
+++ b/src/components/use-landscape.tsx
@@ -5,7 +5,7 @@ const useLandscape = () => {
 
   const isLandscape = width > height
   const landscapeStyle: StyleProp<ViewStyle> = isLandscape
-    ? { marginLeft: height / 2, marginRight: height / 2 }
+    ? { marginLeft: width / 6, marginRight: width / 6 }
     : {}
 
   return { isLandscape, landscapeStyle }

--- a/src/helpers/isTablet.ts
+++ b/src/helpers/isTablet.ts
@@ -1,0 +1,7 @@
+import { Dimensions, Platform } from 'react-native'
+
+const window = Dimensions.get( 'window' )
+const { width, height } = window
+const isTablet = ( Platform.OS === 'ios' && Platform.isPad ) || ( Platform.OS === 'android' && ( ( width >= 960 && height >= 720 ) || ( width >= 720 && width >= 960 ) ) )
+
+export default isTablet

--- a/src/helpers/isTablet.ts
+++ b/src/helpers/isTablet.ts
@@ -2,6 +2,6 @@ import { Dimensions, Platform } from 'react-native'
 
 const window = Dimensions.get( 'window' )
 const { width, height } = window
-const isTablet = ( Platform.OS === 'ios' && Platform.isPad ) || ( Platform.OS === 'android' && ( ( width >= 960 && height >= 720 ) || ( width >= 720 && width >= 960 ) ) )
+const isTablet = ( Platform.OS === 'ios' && Platform.isPad ) || ( Platform.OS === 'android' && ( ( width >= 960 && height >= 720 ) || ( width >= 720 && height >= 960 ) ) )
 
 export default isTablet

--- a/src/screens/Gurbani/index.tsx
+++ b/src/screens/Gurbani/index.tsx
@@ -10,8 +10,6 @@ import BottomBar from './BottomBar'
 import DefaultLines from './DefaultLines'
 import ReaderLines from './ReaderLines'
 
-const xlarge = isTablet
-
 type Loaders = {
   [screen in ContentType]: ( id: string ) => Promise<{ id: string, lines: LineData[] }>
 }
@@ -37,7 +35,7 @@ const GurbaniScreen = ( {
     <Container safeArea left right>
       {data && <Lines key={data.id} id={data.id} lines={data.lines} />}
 
-      {!xlarge && <BottomBar />}
+      {!isTablet && <BottomBar />}
     </Container>
   )
 }

--- a/src/screens/Gurbani/index.tsx
+++ b/src/screens/Gurbani/index.tsx
@@ -1,7 +1,7 @@
-import { Platform } from 'react-native'
 import { useQuery } from 'react-query'
 
 import Container from '../../components/Container'
+import isTablet from '../../helpers/isTablet'
 import { getBookmark, getShabad } from '../../services/data'
 import { settings, useSetting } from '../../services/settings'
 import { ContentType, LineData } from '../../types/data'
@@ -9,6 +9,8 @@ import { GurbaniStackScreenProps } from '../../types/navigation'
 import BottomBar from './BottomBar'
 import DefaultLines from './DefaultLines'
 import ReaderLines from './ReaderLines'
+
+const xlarge = isTablet
 
 type Loaders = {
   [screen in ContentType]: ( id: string ) => Promise<{ id: string, lines: LineData[] }>
@@ -35,7 +37,7 @@ const GurbaniScreen = ( {
     <Container safeArea left right>
       {data && <Lines key={data.id} id={data.id} lines={data.lines} />}
 
-      {!( Platform.OS === 'ios' && Platform.isPad ) && <BottomBar />}
+      {!xlarge && <BottomBar />}
     </Container>
   )
 }

--- a/src/screens/Gurbani/index.tsx
+++ b/src/screens/Gurbani/index.tsx
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native'
 import { useQuery } from 'react-query'
 
 import Container from '../../components/Container'
@@ -34,7 +35,7 @@ const GurbaniScreen = ( {
     <Container safeArea left right>
       {data && <Lines key={data.id} id={data.id} lines={data.lines} />}
 
-      <BottomBar />
+      {!( Platform.OS === 'ios' && Platform.isPad ) && <BottomBar />}
     </Container>
   )
 }

--- a/src/screens/GurbaniNavigator.tsx
+++ b/src/screens/GurbaniNavigator.tsx
@@ -9,8 +9,6 @@ import { ContentType } from '../types/data'
 import { GurbaniStackParams, GurbaniStackScreenProps } from '../types/navigation'
 import GurbaniScreen from './Gurbani'
 
-const xlarge = isTablet
-
 const { Navigator, Screen } = createNativeStackNavigator<GurbaniStackParams>()
 
 const styles = StyleSheet.create( {
@@ -43,7 +41,7 @@ const getOptions = ( {
   ),
   headerRight: () => (
     <HeaderButtons HeaderButtonComponent={IconHeaderButton}>
-      {xlarge
+      {isTablet
       && (
       <>
         <Item

--- a/src/screens/GurbaniNavigator.tsx
+++ b/src/screens/GurbaniNavigator.tsx
@@ -50,9 +50,26 @@ const getOptions = ( {
   ),
   headerRight: () => (
     <HeaderButtons HeaderButtonComponent={IconHeaderButton}>
+      {Platform.OS === 'ios' && Platform.isPad
+      && (
+      <>
+        <Item
+          title="search"
+          iconName="search-outline"
+          testID="navbar-settings"
+          onPress={() => navigation.navigate( 'Root.Search' )}
+        />
+        <Item
+          title="collections"
+          iconName="bookmark-outline"
+          testID="navbar-settings"
+          onPress={() => navigation.navigate( 'Root.Collections' )}
+        />
+      </>
+      )}
       <Item
         title="settings"
-        iconName="ios-options-outline"
+        iconName="options-outline"
         testID="navbar-settings"
         onPress={() => navigation.navigate( 'Home.Tab.Settings', { screen: 'Settings.View' } )}
       />

--- a/src/screens/GurbaniNavigator.tsx
+++ b/src/screens/GurbaniNavigator.tsx
@@ -14,11 +14,6 @@ import GurbaniScreen from './Gurbani'
 const { Navigator, Screen } = createNativeStackNavigator<GurbaniStackParams>()
 
 const styles = StyleSheet.create( {
-  headerIcon: {
-    color: Colors.PrimaryText,
-    fontSize: 28,
-    ...px( 10 ),
-  },
   headerTitle: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/screens/GurbaniNavigator.tsx
+++ b/src/screens/GurbaniNavigator.tsx
@@ -1,5 +1,5 @@
 import { createNativeStackNavigator, NativeStackNavigationOptions } from '@react-navigation/native-stack'
-import { Image, StyleSheet, View } from 'react-native'
+import { Image, Platform, StyleSheet, View } from 'react-native'
 import { HeaderButtons, Item } from 'react-navigation-header-buttons'
 
 import logo from '../../assets/images/logo.png'

--- a/src/screens/GurbaniNavigator.tsx
+++ b/src/screens/GurbaniNavigator.tsx
@@ -67,9 +67,7 @@ const getOptions = ( {
       />
     </HeaderButtons>
   ),
-  headerTitle: () => (
-    <Logo />
-  ),
+  headerTitle: Logo,
 } )
 
 const GurbaniNavigator = () => (

--- a/src/screens/GurbaniNavigator.tsx
+++ b/src/screens/GurbaniNavigator.tsx
@@ -18,10 +18,10 @@ const styles = StyleSheet.create( {
     alignItems: 'center',
   },
   left: {
-    marginLeft: Units.HorizontalLayoutMargin * -1,
+    marginLeft: -Units.HorizontalLayoutMargin,
   },
   right: {
-    marginRight: Units.HorizontalLayoutMargin * -1,
+    marginRight: -Units.HorizontalLayoutMargin,
   },
 } )
 

--- a/src/screens/GurbaniNavigator.tsx
+++ b/src/screens/GurbaniNavigator.tsx
@@ -1,13 +1,16 @@
 import { createNativeStackNavigator, NativeStackNavigationOptions } from '@react-navigation/native-stack'
-import { Image, Platform, StyleSheet, View } from 'react-native'
+import { Image, StyleSheet, View } from 'react-native'
 import { HeaderButtons, Item } from 'react-navigation-header-buttons'
 
 import logo from '../../assets/images/logo.png'
 import IconHeaderButton from '../components/IconHeaderButton'
 import Typography from '../components/Typography'
+import isTablet from '../helpers/isTablet'
 import { ContentType } from '../types/data'
 import { GurbaniStackParams, GurbaniStackScreenProps } from '../types/navigation'
 import GurbaniScreen from './Gurbani'
+
+const xlarge = isTablet
 
 const { Navigator, Screen } = createNativeStackNavigator<GurbaniStackParams>()
 
@@ -51,7 +54,7 @@ const getOptions = ( {
   ),
   headerRight: () => (
     <HeaderButtons HeaderButtonComponent={IconHeaderButton}>
-      {Platform.OS === 'ios' && Platform.isPad
+      {xlarge
       && (
       <>
         <Item

--- a/src/screens/GurbaniNavigator.tsx
+++ b/src/screens/GurbaniNavigator.tsx
@@ -5,8 +5,6 @@ import { HeaderButtons, Item } from 'react-navigation-header-buttons'
 import logo from '../../assets/images/logo.png'
 import IconHeaderButton from '../components/IconHeaderButton'
 import Typography from '../components/Typography'
-import Colors from '../themes/colors'
-import { px } from '../themes/utils'
 import { ContentType } from '../types/data'
 import { GurbaniStackParams, GurbaniStackScreenProps } from '../types/navigation'
 import GurbaniScreen from './Gurbani'
@@ -18,6 +16,9 @@ const styles = StyleSheet.create( {
     flexDirection: 'row',
     alignItems: 'center',
   },
+  left: {
+    marginLeft: -16,
+  },
   logoIcon: {
     width: 28,
     height: 28,
@@ -27,6 +28,9 @@ const styles = StyleSheet.create( {
     fontSize: 20,
     lineHeight: 24,
     fontWeight: '300',
+  },
+  right: {
+    marginRight: -16,
   },
 } )
 
@@ -41,6 +45,7 @@ const getOptions = ( {
         iconName="menu"
         testID="navbar-menu"
         disabled
+        style={styles.left}
       />
     </HeaderButtons>
   ),
@@ -68,6 +73,7 @@ const getOptions = ( {
         iconName="options-outline"
         testID="navbar-settings"
         onPress={() => navigation.navigate( 'Home.Tab.Settings', { screen: 'Settings.View' } )}
+        style={styles.right}
       />
     </HeaderButtons>
   ),

--- a/src/screens/GurbaniNavigator.tsx
+++ b/src/screens/GurbaniNavigator.tsx
@@ -1,10 +1,9 @@
 import { createNativeStackNavigator, NativeStackNavigationOptions } from '@react-navigation/native-stack'
-import { Image, StyleSheet, View } from 'react-native'
+import { StyleSheet } from 'react-native'
 import { HeaderButtons, Item } from 'react-navigation-header-buttons'
 
-import logo from '../../assets/images/logo.png'
 import IconHeaderButton from '../components/IconHeaderButton'
-import Typography from '../components/Typography'
+import Logo from '../components/Logo'
 import isTablet from '../helpers/isTablet'
 import { ContentType } from '../types/data'
 import { GurbaniStackParams, GurbaniStackScreenProps } from '../types/navigation'
@@ -21,16 +20,6 @@ const styles = StyleSheet.create( {
   },
   left: {
     marginLeft: -16,
-  },
-  logoIcon: {
-    width: 28,
-    height: 28,
-    marginRight: 6.5,
-  },
-  logoText: {
-    fontSize: 20,
-    lineHeight: 24,
-    fontWeight: '300',
   },
   right: {
     marginRight: -16,
@@ -81,10 +70,7 @@ const getOptions = ( {
     </HeaderButtons>
   ),
   headerTitle: () => (
-    <View style={styles.headerTitle}>
-      <Image style={styles.logoIcon} source={logo} />
-      <Typography style={styles.logoText}>Shabad OS</Typography>
-    </View>
+    <Logo />
   ),
 } )
 

--- a/src/screens/GurbaniNavigator.tsx
+++ b/src/screens/GurbaniNavigator.tsx
@@ -5,6 +5,7 @@ import { HeaderButtons, Item } from 'react-navigation-header-buttons'
 import IconHeaderButton from '../components/IconHeaderButton'
 import Logo from '../components/Logo'
 import isTablet from '../helpers/isTablet'
+import Units from '../themes/units'
 import { ContentType } from '../types/data'
 import { GurbaniStackParams, GurbaniStackScreenProps } from '../types/navigation'
 import GurbaniScreen from './Gurbani'
@@ -17,10 +18,10 @@ const styles = StyleSheet.create( {
     alignItems: 'center',
   },
   left: {
-    marginLeft: -16,
+    marginLeft: Units.HorizontalLayoutMargin * -1,
   },
   right: {
-    marginRight: -16,
+    marginRight: Units.HorizontalLayoutMargin * -1,
   },
 } )
 

--- a/src/screens/GurbaniNavigator.tsx
+++ b/src/screens/GurbaniNavigator.tsx
@@ -21,10 +21,11 @@ const styles = StyleSheet.create( {
   logoIcon: {
     width: 28,
     height: 28,
-    marginRight: 10,
+    marginRight: 6.5,
   },
   logoText: {
     fontSize: 20,
+    lineHeight: 24,
     fontWeight: '300',
   },
 } )

--- a/src/screens/GurbaniNavigator.tsx
+++ b/src/screens/GurbaniNavigator.tsx
@@ -42,8 +42,7 @@ const getOptions = ( {
   ),
   headerRight: () => (
     <HeaderButtons HeaderButtonComponent={IconHeaderButton}>
-      {isTablet
-      && (
+      {isTablet && (
       <>
         <Item
           title="search"

--- a/src/themes/units.ts
+++ b/src/themes/units.ts
@@ -14,6 +14,7 @@ enum Units {
   ThumbFingerRatio = 1.5,
   Separator = StyleSheet.hairlineWidth,
   BorderRadius = 25,
+  ThinSplitViewWidth = 350,
 }
 
 export default Units


### PR DESCRIPTION
<!-- Please title as if this PR were a single commit to our main branch. -->
<!-- https://docs.shabados.com/community/coding-guidelines#commit-messages -->
<!-- Also don't forget to add any reviewer(s) and link the related issue! -->

### Summary

- Determine tablet using built in react native (iPad) or dp guestimate (Android)
- On tablet: hide bottom bar and add search/collections to top bar
- React Navigation comes prepared for tablets on iPad, no need to redesign search/collections modal
- Add split view for iPad so you can multitask (e.g. watch keertan on YouTube + Shabad OS on side)
- Hide title "Shabad OS" from logo when the split view is too narrow

#### Question

- Is "helpers" the correct folder for something like the "isTablet.tsx" file?

#### Screenshots

<img width="256" alt="Screen Shot 2022-04-24 at 14 35 38" src="https://user-images.githubusercontent.com/14130567/164991243-75e29e45-248d-4c76-835e-c0195a7784da.png">

<img width="256" alt="Screen Shot 2022-04-24 at 14 38 42" src="https://user-images.githubusercontent.com/14130567/164991369-6792e829-818b-4075-a9d2-324ef79cbdec.png">

<img width="256" alt="Screen Shot 2022-04-24 at 14 34 28" src="https://user-images.githubusercontent.com/14130567/164991202-9b863777-a9f5-4ebd-b00a-4f5b929002bc.png">

<img width="256" alt="Screen Shot 2022-04-24 at 14 39 57" src="https://user-images.githubusercontent.com/14130567/164991427-c933c4e7-fa0b-4695-8eae-0ed779ad09a1.png">

<img width="256" alt="Screen Shot 2022-04-24 at 14 36 07" src="https://user-images.githubusercontent.com/14130567/164991260-28b47855-3646-4a69-8808-fcff1f75557f.png">

<img width="256" alt="Screen Shot 2022-04-24 at 14 36 31" src="https://user-images.githubusercontent.com/14130567/164991285-5fc9a1a2-d9d8-4a24-a957-05f018f1559a.png">

<img width="256" alt="image" src="https://user-images.githubusercontent.com/14130567/164997979-47ae34ad-37d7-4fe1-accd-d825ba87aa13.png">

<img width="256" alt="image" src="https://user-images.githubusercontent.com/14130567/164998011-5d4124ee-7aa6-4bbe-8dc2-6c963dbb1f6f.png">

<img width="256" alt="image" src="https://user-images.githubusercontent.com/14130567/164993227-80d2a164-019c-4667-8694-7f037dccd92d.png">

<img width="256" alt="image" src="https://user-images.githubusercontent.com/14130567/164995674-4cf03791-e5f6-4c8f-abe6-9de199d4a70f.png">

<img width="256" alt="image" src="https://user-images.githubusercontent.com/14130567/164996472-93036303-57ed-4d2e-b636-feb6f1978d7c.png">


### Test

WIP Checklist:
- [x] Check that iPad works
- [x] Make sure split view on iPad works
- [x] Check that Android works
- [x] Re-do bottom bar into top bar for tablets
- [x] Fix width of drawer (Settings > App Language)

### Duration

4 hours (significant amount wasted on padding issues for Android, decidedly that is a separate issue... so it might save me time on the next PR)

Closes #265 