### PR TITLE
build(android): update Gradle heap size to 4GB

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -24,5 +24,7 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 
+org.gradle.jvmargs=-Xmx2g -XX\:MaxHeapSize\=4g
+
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.162.0


### PR DESCRIPTION
Android build was failing due to Java heap size error from Gradle. This PR bumps build heap size up to 4GB which allows the Gradle build to succeed.